### PR TITLE
Fix measurement retrieval and creation

### DIFF
--- a/lib/interfaces/database_interface.dart
+++ b/lib/interfaces/database_interface.dart
@@ -13,11 +13,11 @@ abstract class DatabaseInterface {
   Future<UserProtectedData?> getUserProtectedData(String uid);
   Future<UserPrivateData?> getUserPrivateData(String uid);
   Future<String?> createUserPublicData(String uid, Map<String, dynamic> data);
-  Future<String?> createUserProtectedData(
-      String uid, Map<String, dynamic> data);
+  Future<String?> createUserProtectedData(String uid, Map<String, dynamic> data);
   Future<String?> createUserPrivateData(String uid, Map<String, dynamic> data);
   Future<RoutineData?> getUserRoutine(String uid);
   Future<List<UserMeasurements>?>  getUserMeasurements(String uid);
+  Future<UserMeasurements?>  getUserLatestMeasurement(String uid);
   Future<String?> createMeasurement(String uid, Map<String, dynamic> data);
   Future<List<Exercise>> getExercises();
   Future<RoutineData?> getUserLastestRoutine(String uid);

--- a/lib/interfaces/database_interface.dart
+++ b/lib/interfaces/database_interface.dart
@@ -17,7 +17,8 @@ abstract class DatabaseInterface {
       String uid, Map<String, dynamic> data);
   Future<String?> createUserPrivateData(String uid, Map<String, dynamic> data);
   Future<RoutineData?> getUserRoutine(String uid);
-  Future<UserMeasurements?> getUserMeasurements(String uid);
+  Future<List<UserMeasurements>?>  getUserMeasurements(String uid);
+  Future<String?> createMeasurement(String uid, Map<String, dynamic> data);
   Future<List<Exercise>> getExercises();
   Future<RoutineData?> getUserLastestRoutine(String uid);
   Future<String?> createRoutine(Map<String, dynamic> data);

--- a/lib/models/users/user_measurements.dart
+++ b/lib/models/users/user_measurements.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class UserMeasurements {
+  Timestamp? date;
   int age;
   int fatMass;
   int fatPercentage;
@@ -9,6 +10,7 @@ class UserMeasurements {
   int weight;
 
   UserMeasurements({
+    required this.date,
     required this.age,
     required this.fatMass,
     required this.fatPercentage,
@@ -17,7 +19,7 @@ class UserMeasurements {
     required this.weight,
   });
 
-  factory UserMeasurements.fromMap(Map<String, dynamic> map) {
+  factory UserMeasurements.fromJson(Map<String, dynamic> map) {
     final Timestamp a = map['age'] as Timestamp;
     final DateTime birthdate =
         DateTime.fromMicrosecondsSinceEpoch(a.microsecondsSinceEpoch);
@@ -27,6 +29,7 @@ class UserMeasurements {
     final int ageInYears = (period.inDays / 365).floor();
 
     return UserMeasurements(
+      date: map['date'],
       age: ageInYears,
       fatMass: map['fatMass'],
       fatPercentage: map['fatPercentage'],
@@ -37,6 +40,7 @@ class UserMeasurements {
   }
 
   Map<String, dynamic> toJson() => {
+        'date': date,
         'age': age,
         'fatMass': fatMass,
         'fatPercentage': fatPercentage,

--- a/lib/services/db/firebase_firestore_service.dart
+++ b/lib/services/db/firebase_firestore_service.dart
@@ -116,6 +116,24 @@ class DatabaseFirebase implements DatabaseInterface {
   }
 
   @override
+  Future<UserMeasurements?> getUserLatestMeasurement(String uid) async {
+    try {
+      var userMeasurement = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(uid)
+          .collection('measurements')
+          .orderBy('date', descending: true)
+          .limit(1)
+          .get();
+      if (userMeasurement.docs.isNotEmpty) {
+        return UserMeasurements.fromJson(userMeasurement.docs.first.data());
+      }
+    } catch (e) {
+      return null;
+    }
+  }
+
+  @override
   Future<List<UserMeasurements>?> getUserMeasurements(String uid) async {
     try {
       var userMeasurements = await FirebaseFirestore.instance
@@ -124,13 +142,11 @@ class DatabaseFirebase implements DatabaseInterface {
           .collection('measurements')
           .get();
       if (userMeasurements.docs.isNotEmpty) {
-
         return userMeasurements.docs.map((doc) {
           final data = doc.data();
           data.addAll({'uid': doc.id});
           return UserMeasurements.fromJson(data);
         }).toList();
-
       }
       return null;
     } on FirebaseException {

--- a/lib/services/db/firebase_firestore_service.dart
+++ b/lib/services/db/firebase_firestore_service.dart
@@ -101,16 +101,36 @@ class DatabaseFirebase implements DatabaseInterface {
   }
 
   @override
-  Future<UserMeasurements?> getUserMeasurements(String uid) async {
+  Future<String?> createMeasurement(
+      String uid, Map<String, dynamic> data) async {
+    try {
+      await FirebaseFirestore.instance
+          .collection('users')
+          .doc(uid)
+          .collection('measurements')
+          .add(data);
+      return uid;
+    } on FirebaseException {
+      return null;
+    }
+  }
+
+  @override
+  Future<List<UserMeasurements>?> getUserMeasurements(String uid) async {
     try {
       var userMeasurements = await FirebaseFirestore.instance
           .collection('users')
           .doc(uid)
           .collection('measurements')
-          .doc('data')
           .get();
-      if (userMeasurements.exists) {
-        return UserMeasurements.fromMap(userMeasurements.data()!);
+      if (userMeasurements.docs.isNotEmpty) {
+
+        return userMeasurements.docs.map((doc) {
+          final data = doc.data();
+          data.addAll({'uid': doc.id});
+          return UserMeasurements.fromJson(data);
+        }).toList();
+
       }
       return null;
     } on FirebaseException {


### PR DESCRIPTION
This pull request fixes the `getUserMeasurements` method to correctly retrieve all user measurements and adds a new method `getUserLatestMeasurement` to retrieve the latest measurement. Additionally, it adds a new method `createMeasurement` to create a new measurement for a user.