### PR TITLE
Add successful users to weekly challenge

### DIFF
--- a/lib/models/weekly_challeges/weekly_challenge.dart
+++ b/lib/models/weekly_challeges/weekly_challenge.dart
@@ -5,11 +5,13 @@ class WeeklyChallenge {
   Timestamp date;
   String pin;
   List<RoutineExercise> exercises;
+  List<String> successfulUsers;
 
   WeeklyChallenge({
     required this.date,
     required this.pin,
     required this.exercises,
+    required this.successfulUsers,
   });
 
   factory WeeklyChallenge.fromJson(Map<String, dynamic> json) {
@@ -19,6 +21,7 @@ class WeeklyChallenge {
       exercises: (json['exercises'] as List)
           .map((e) => RoutineExercise.fromJson(e))
           .toList(),
+      successfulUsers: (json['successfulUsers'] as List).map((e) => e.toString()).toList(),
     );
   }
 
@@ -27,6 +30,7 @@ class WeeklyChallenge {
       'date': date,
       'pin': pin,
       'exercises': exercises.map((e) => e.toJson()).toList(),
+      'successfulUsers': successfulUsers,
     };
   }
 }


### PR DESCRIPTION
This pull request adds a new field to the WeeklyChallenge class, `successfulUsers`, which is a list of strings representing the user ids of users who successfully completed the challenge. This will allow us to track and display the users who are most active in completing the weekly challenges.